### PR TITLE
Updating mbed-os to mbed-os-5.3.2

### DIFF
--- a/test_example_update1/mbed-os.lib
+++ b/test_example_update1/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0789928ee7f2db08a419fa4a032fffd9bd477aa7
+https://github.com/ARMmbed/mbed-os/#2885c1b41e63158cb6faf5f107cd821ae06ef26c

--- a/test_example_update2/mbed-os.lib
+++ b/test_example_update2/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0789928ee7f2db08a419fa4a032fffd9bd477aa7
+https://github.com/ARMmbed/mbed-os/#2885c1b41e63158cb6faf5f107cd821ae06ef26c


### PR DESCRIPTION
Please test/merge this PR and then tag Master with mbed-os-5.3.2