### PR TITLE
Updating mbed-os to mbed-os-5.5.0-rc1

### DIFF
--- a/test_example_update1/mbed-os.lib
+++ b/test_example_update1/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0789928ee7f2db08a419fa4a032fffd9bd477aa7
+https://github.com/ARMmbed/mbed-os/#92fbf2a9b3988d430482fc25a6077f2462e2a634

--- a/test_example_update2/mbed-os.lib
+++ b/test_example_update2/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0789928ee7f2db08a419fa4a032fffd9bd477aa7
+https://github.com/ARMmbed/mbed-os/#92fbf2a9b3988d430482fc25a6077f2462e2a634


### PR DESCRIPTION
Please test this PR.
If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.5.0-rc1