### PR TITLE
Updating mbed-os to mbed-os-5.8.3

### DIFF
--- a/test_example_update1/mbed-os.lib
+++ b/test_example_update1/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6ff720302e43c7a420232d134e786811cc7281a9
+https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe

--- a/test_example_update2/mbed-os.lib
+++ b/test_example_update2/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#6ff720302e43c7a420232d134e786811cc7281a9
+https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.8.3 . 