### PR TITLE
Updating mbed-os to mbed-os-5.8.2

### DIFF
--- a/test_example_update1/mbed-os.lib
+++ b/test_example_update1/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#f9ee4e849f8cbd64f1ec5fdd4ad256585a208360

--- a/test_example_update2/mbed-os.lib
+++ b/test_example_update2/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#c05d72c3c005fbb7e92c3994c32bda45218ae7fe
+https://github.com/ARMmbed/mbed-os/#f9ee4e849f8cbd64f1ec5fdd4ad256585a208360


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.8.2 . 